### PR TITLE
[DOC] Remove old absolute referenced symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Install using composer:
 
     composer require mittwald-flow/symlink-publishing
 
+Next delete all absolute referenced symlinks, etc., from the _Resources folder:
+
+    rm -rf Web/_Resources
+
+Finally reissue the relative referenced symlinks, etc.:
+
+    ./flow resources:publish
+
 Configuration
 -------------
 


### PR DESCRIPTION
It wasn't mentioned that you need to manually remove all old references to the absolutely referenced symlinks by deleting the _Resources directory and recreating resource symlinks.
