### PR TITLE
Upadte Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,27 @@ You can configure relative symlink publishing in the Flow settings.
 			localWebDirectoryPersistentResourcesTarget:
 			  target: 'Mw\SymlinkPublishing\Resource\Target\FileSystemSymlinkTarget'
 			  targetOptions:
-				relativeSymlinks: TRUE
+				  relativeSymlinks: TRUE
 			localWebDirectoryStaticResourcesTarget:
 			  target: 'Mw\SymlinkPublishing\Resource\Target\FileSystemSymlinkTarget'
 			  targetOptions:
-				relativeSymlinks: TRUE
+				  relativeSymlinks: TRUE
+
+If you change the FLOW_ROOTPATH (for exmaple you use the TYPO3/Surf deployment) and your webserver documentRoot is a other one as the FLOW_ROOTPATH, you have to change the **path** at the **resource** -> **targets** -> **targetOptions**
+from '%FLOW_PATH_WEB%' to '%FLOW_PATH_ROOT%'.
+
+Add following to your global or site package Settings.yaml
+
+	TYPO3:
+	  Flow:
+		resource:
+		  targets:
+			localWebDirectoryPersistentResourcesTarget:
+			  targetOptions:
+				  path: '%FLOW_PATH_ROOT%Web/_Resources/Persistent/'
+			localWebDirectoryStaticResourcesTarget:
+			  targetOptions:
+				  path: '%FLOW_PATH_ROOT%Web/_Resources/Static/Packages/'
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ You can configure relative symlink publishing in the Flow settings.
 			localWebDirectoryPersistentResourcesTarget:
 			  target: 'Mw\SymlinkPublishing\Resource\Target\FileSystemSymlinkTarget'
 			  targetOptions:
-				  relativeSymlinks: TRUE
+				relativeSymlinks: TRUE
 			localWebDirectoryStaticResourcesTarget:
 			  target: 'Mw\SymlinkPublishing\Resource\Target\FileSystemSymlinkTarget'
 			  targetOptions:
-				  relativeSymlinks: TRUE
+				relativeSymlinks: TRUE
 
 
 ### Change Flow root path
@@ -53,10 +53,10 @@ Add following to your global or site package Settings.yaml
 		  targets:
 			localWebDirectoryPersistentResourcesTarget:
 			  targetOptions:
-				  path: '%FLOW_PATH_ROOT%Web/_Resources/Persistent/'
+				path: '%FLOW_PATH_ROOT%Web/_Resources/Persistent/'
 			localWebDirectoryStaticResourcesTarget:
 			  targetOptions:
-				  path: '%FLOW_PATH_ROOT%Web/_Resources/Static/Packages/'
+				path: '%FLOW_PATH_ROOT%Web/_Resources/Static/Packages/'
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ You can configure relative symlink publishing in the Flow settings.
 			  targetOptions:
 				  relativeSymlinks: TRUE
 
-If you change the FLOW_ROOTPATH (for exmaple you use the TYPO3/Surf deployment) and your webserver documentRoot is a other one as the FLOW_ROOTPATH, you have to change the **path** at the **resource** -> **targets** -> **targetOptions**
+
+### Change Flow root path
+
+If you change the FLOW_ROOTPATH (for exmaple you use the TYPO3/Surf deployment) and your webserver documentRoot is a other one as the FLOW_ROOTPATH, you have to change the **path** options at the **resource** -> **targets** -> **targetOptions**
 from '%FLOW_PATH_WEB%' to '%FLOW_PATH_ROOT%'.
 
 Add following to your global or site package Settings.yaml


### PR DESCRIPTION
Hello mw developers,

we had an issue with a customer of us, who host his Neos website at Mittwald. We use the TYPO3 Surf deployment tool. For this the webserver is linked to a own directory where some unversioned files exist, like the robots and htaccess file. Also we had to adjust the Flow root path because the web resource directory of Neos is symlinked to this directory. With fully qualified symlinks we had no problem, but with relativ symlinks. We had the issue that all public resources are wrong symlinked. We could solve this if we overwrite the path at resource -> targetOptions from  '%FLOW_PATH_WEB%' to '%FLOW_PATH_ROOT%'.

Best regards,
Marcus
